### PR TITLE
修复了linux下不能使用的bug

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -230,6 +230,8 @@ if [ "$os" = "Darwin" ]; then
 elif [ "$os" = "Linux" ]; then
     echo "- patchelf"
     cd "$prefix"/bin
+    rm -rf "$prefix"/lib/libnfc.so.6
+    ln -s "$prefix"/lib/libnfc.so "$prefix"/lib/libnfc.so.6
     for i in *; do
         patchelf --set-rpath '$ORIGIN/../lib/' "$prefix"/bin/"$i"
     done


### PR DESCRIPTION
libnfc.so.6是个文本文件，导致了：
NFCToolsGUI-linux-x64/resources/framework/bin/../lib/libnfc.so.6: file too short

我简单粗暴的把这个文件替换成了libnfc.so的软链接(www
然后能用了，虽然还是存在error	libnfc.driver.pn532_uart	Application level error detected的问题，大概是我加完用户组没relogin()

希望maintainer能够merge