### PR TITLE
修复了导致 issue #3 中提到的 "使用只采集不计算功能时报错信息" 的问题

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -171,6 +171,7 @@ const actions = {
         catch (e) {createHardNestedWindow()}},
     "hard-nested-config-done": (configs) => {
         if (configs.autoRun) {
+            fs.writeFileSync(noncesFilesPath, '');
             readICThenExec(i18n("lod_msg_start_auto_hard_nested"),
                 `${i18n("indicator_doing_hard_nested")} - ${totalUnknownKeys - unknownKeyInfo.length + 1}/${totalUnknownKeys}`,
                 false,


### PR DESCRIPTION
修复了在使用 HardNestedDecryption 的 Auto Run 时程序调用 `resources\framework\bin\libnfc-collect.exe` 前未创建 `nonces.bin`的问题